### PR TITLE
Adding an option for allowed-credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ You can install this library from Quicklisp, but you want to receive updates qui
 
 Returns a Clack middleware which can be used to override `CORS` `HTTP` headers in response.
 
-You can pass arguments `ALLOWED-ORIGIN`, `ALLOWED-HEADERS` and `ALLOWED-METHODS` to override corresponding headers.
+You can pass arguments `ALLOWED-ORIGIN`, `ALLOWED-HEADERS`, `ALLOWED-CREDENTIALS` and `ALLOWED-METHODS` to override corresponding headers.
 
 If given, these arguments are extend headers, returned by the main application. For example, if main application
 already returns `Access-Control-Allow-Headers` with value `Content-Type`, then it will be overwritten with
@@ -77,6 +77,10 @@ Default value to return as `Access-Control-Allow-Headers` `HTTP` header.
 ### [variable](9eb4) `clack-cors:*default-allowed-methods*` nil
 
 Default value to return as `Access-Control-Allow-Methods` `HTTP` header.
+
+### [variable](9eb4) `clack-cors:*default-allowed-credentials*` nil
+
+Default value to return as `Access-Control-Allow-Credentials` `HTTP` header.
 
 <a id="x-28CLACK-CORS-3A-2ADEFAULT-ERROR-RESPONSE-2A-20-28VARIABLE-29-29"></a>
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can install this library from Quicklisp, but you want to receive updates qui
 
 <a id="x-28CLACK-CORS-3AMAKE-CORS-MIDDLEWARE-20FUNCTION-29"></a>
 
-### [function](308b) `clack-cors:make-cors-middleware` app &key (allowed-origin \*default-allowed-origin\*) (allowed-headers \*default-allowed-headers\*) (allowed-methods \*default-allowed-methods\*) (error-response \*default-error-response\*)
+### [function](308b) `clack-cors:make-cors-middleware` app &key (allowed-origin \*default-allowed-origin\*) (allowed-headers \*default-allowed-headers\*) (allowed-methods \*default-allowed-methods\*) (allowed-credentials \*default-allowed-credentials\*) (error-response \*default-error-response\*)
 
 Returns a Clack middleware which can be used to override `CORS` `HTTP` headers in response.
 

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -77,7 +77,7 @@
                                  (error-response *default-error-response*))
   "Returns a Clack middleware which can be used to override CORS HTTP headers in response.
 
-   You can pass arguments ALLOWED-ORIGIN, ALLOWED-HEADERS and ALLOWED-METHODS to override corresponding headers.
+   You can pass arguments ALLOWED-ORIGIN, ALLOWED-HEADERS,ALLOWED-CREDENTIALS and ALLOWED-METHODS to override corresponding headers.
 
    If given, these arguments are extend headers, returned by the main application. For example, if main application
    already returns `Access-Control-Allow-Headers` with value `Content-Type`, then it will be overwritten with


### PR DESCRIPTION
If using Clath authentication, there is a need to propagate the access-control-allow-credentials header, so that CORS works even for resources that needs authentication.

I tried a lot of ways to make this work through snooze/clack but wasn't able to make any of my ideas survive all the way to the browser.

However, when I tried to fork and modify your library here, it worked very well (and in a way I could understand as well!).
I hope you think this fits within the scope of the library,but understand if you think it might be an edge-case.